### PR TITLE
fix: bring back compute coverage options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,6 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - run: npm run test --test.spec.ts
+      - run: npm run test-test
       - run: npm run lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,6 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
+      - run: npm run test --test.spec.ts
       - run: npm run lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ node_modules/
 
 dist/
 build/
+# generated file by movevm
+.trace
+.coverage_map.mvcov
 doc/

--- a/README.md
+++ b/README.md
@@ -123,5 +123,6 @@ export interface TestOptions {
     reportStatistics?: boolean
     reportStorageOnError?: boolean
     ignoreCompileWarnings?: boolean
+    computeCoverage?: boolean
 }
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "lint": "npx eslint . --fix",
     "build": "tsc --build",
-    "test": "jest --no-cache",
+    "test": "jest --no-cache --testPathIgnorePatterns test.spec.ts",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/builder.js",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "The JavaScript Move Builder for Initia",
   "license": "MIT",
   "author": "Initia Foundation",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "npx eslint . --fix",
     "build": "tsc --build",
     "test": "jest --no-cache --testPathIgnorePatterns test.spec.ts",
+    "test-test": "jest test.spec.ts",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -198,7 +198,7 @@ export class MoveBuilder {
           report_statistics: options?.reportStatistics || false,
           report_storage_on_error: options?.reportStorageOnError || false,
           ignore_compile_warnings: options?.ignoreCompileWarnings || false,
-          compute_coverage: false,
+          compute_coverage: options?.computeCoverage || false,
         })
         .toBytes()
     )

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -96,4 +96,9 @@ export interface TestOptions {
    * Ignore compiler's warning, and continue run tests.(default false)
    */
   ignoreCompileWarnings?: boolean
+
+  /**
+   * Collect coverage information for later use with the various `move coverage` subcommands
+   */
+  computeCoverage?: boolean
 }

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -14,10 +14,12 @@ describe('test move package', () => {
       computeCoverage: true,
     })
     expect(testResult).toEqual('ok')
+    await builder.clean({})
   }, 100000000)
 
   it('executes tests without options', async () => {
     const testResult = await builder.test({})
     expect(testResult).toEqual('ok')
+    await builder.clean({})
   }, 100000000)
 })

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -5,20 +5,19 @@ describe('test move package', () => {
   const contractDir = path.resolve(__dirname, 'contract/simple')
   const builder = new MoveBuilder(contractDir, {})
 
-  it('executes tests successfully', async () => {
-    const testResult = await builder.test({
-      filter: 'test_simple',
-    })
-    expect(testResult).toEqual('ok')
-  }, 100000000)
-
   it('executes tests with options', async () => {
     const testResult = await builder.test({
       filter: 'test_simple2',
       reportStatistics: true,
       reportStorageOnError: true,
       ignoreCompileWarnings: true,
+      computeCoverage: true,
     })
+    expect(testResult).toEqual('ok')
+  }, 100000000)
+
+  it('executes tests without options', async () => {
+    const testResult = await builder.test({})
     expect(testResult).toEqual('ok')
   }, 100000000)
 })


### PR DESCRIPTION
## Fix
- Bring back compute coverage options
## Test
- Add test with options case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `computeCoverage` option in the testing configuration, allowing users to specify whether to compute coverage during tests.

- **Bug Fixes**
  - Enhanced the flexibility of the testing functionality to utilize user-specified options for coverage computation.

- **Documentation**
  - Updated `README.md` to reflect the new `computeCoverage` property in the `TestOptions` interface.

- **Chores**
  - Modified the `.gitignore` to exclude generated files from version control.
  - Updated the testing workflow to include an additional step for executing specific tests.
  - Added a new test script to facilitate direct testing of specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->