### PR TITLE
fix: use base64 encode instead of utf8 in cString

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
       - run: npm install
       - run: npm run build
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/builder.js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "The JavaScript Move Builder for Initia",
   "license": "MIT",
   "author": "Initia Foundation",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -71,8 +71,8 @@ export class MoveBuilder {
     rawCompilerPayload.is_nil = false
     rawCompilerPayload.len = compilerPayloadBytes.length
     rawCompilerPayload.ptr = ref.allocCString(
-      compilerPayloadBytes.toString(),
-      'utf-8'
+      compilerPayloadBytes.toString('base64'),
+      'base64'
     )
 
     return rawCompilerPayload
@@ -206,7 +206,7 @@ export class MoveBuilder {
     const rawTestOpt = testOpt.deref()
     rawTestOpt.is_nil = false
     rawTestOpt.len = testOptBytes.length
-    rawTestOpt.ptr = ref.allocCString(testOptBytes.toString(), 'utf-8')
+    rawTestOpt.ptr = ref.allocCString(testOptBytes.toString('base64'), 'base64')
 
     return handleResponse(
       libcompiler.test_move_package.async,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -33,8 +33,8 @@ export class MoveBuilder {
    */
   private makeRawBuildConfig = () => {
     const additionalNamedAddresses: [string, Uint8Array][] = this.buildOptions
-      .addtionalNamedAddresses
-      ? this.buildOptions.addtionalNamedAddresses.map(([name, address]) => {
+      .additionalNamedAddresses
+      ? this.buildOptions.additionalNamedAddresses.map(([name, address]) => {
           if (address.startsWith('0x')) {
             address = address.slice(2).padStart(64, '0')
           }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -60,7 +60,7 @@ export interface BuildOptions {
   /**
    * Additional named address mapping. Useful for tools in Rust.
    */
-  addtionalNamedAddresses?: [string, string][]
+  additionalNamedAddresses?: [string, string][]
 }
 
 export interface CleanOptions {

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -17,7 +17,7 @@ describe('build move package', () => {
     languageVersion: '1',
     addtionalNamedAddresses: [
       ['test', '0x4'],
-      ['test2', '0x5'],
+      ['test2', '0x4c4e8f7def3c24453ae7eee7d9aee9b7556a26a0'],
     ],
   })
   const dummyModulePath = path.join(
@@ -35,43 +35,76 @@ describe('build move package', () => {
   })
 
   it('decodes module bytes correctly', async () => {
-    const binary = await builder.get('dummy')
-    const expectedDecoded = JSON.stringify({
-      address: '0x4',
-      name: 'dummy',
-      friends: [],
-      exposed_functions: [
-        {
-          name: 'return_0',
-          visibility: 'public',
-          is_entry: false,
-          is_view: false,
-          generic_type_params: [],
-          params: [],
-          return: ['u32'],
-        },
-        {
-          name: 'return_10',
-          visibility: 'public',
-          is_entry: false,
-          is_view: false,
-          generic_type_params: [],
-          params: [],
-          return: ['u32'],
-        },
-      ],
-      structs: [],
-    })
+    const dummy = await builder.get('dummy')
 
-    expect(await MoveBuilder.decode_module_bytes(binary)).toEqual(
-      expectedDecoded
+    expect(await MoveBuilder.decode_module_bytes(dummy)).toEqual(
+      JSON.stringify({
+        address: '0x4',
+        name: 'dummy',
+        friends: [],
+        exposed_functions: [
+          {
+            name: 'return_0',
+            visibility: 'public',
+            is_entry: false,
+            is_view: false,
+            generic_type_params: [],
+            params: [],
+            return: ['u32'],
+          },
+          {
+            name: 'return_10',
+            visibility: 'public',
+            is_entry: false,
+            is_view: false,
+            generic_type_params: [],
+            params: [],
+            return: ['u32'],
+          },
+        ],
+        structs: [],
+      })
+    )
+    const hihi = await builder.get('hihi')
+
+    expect(await MoveBuilder.decode_module_bytes(hihi)).toEqual(
+      JSON.stringify({
+        address: '0x4c4e8f7def3c24453ae7eee7d9aee9b7556a26a0',
+        name: 'hihi',
+        friends: [],
+        exposed_functions: [
+          {
+            name: 'return_0',
+            visibility: 'public',
+            is_entry: false,
+            is_view: false,
+            generic_type_params: [],
+            params: [],
+            return: ['u32'],
+          },
+          {
+            name: 'return_10',
+            visibility: 'public',
+            is_entry: false,
+            is_view: false,
+            generic_type_params: [],
+            params: [],
+            return: ['u32'],
+          },
+        ],
+        structs: [],
+      })
     )
   })
 
   it('reads module info correctly', async () => {
-    const binary = await builder.get('dummy')
-    expect(await MoveBuilder.read_module_info(binary)).toEqual(
+    const dummy = await builder.get('dummy')
+    expect(await MoveBuilder.read_module_info(dummy)).toEqual(
       '{"address":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4],"name":"dummy"}'
+    )
+    const hihi = await builder.get('hihi')
+    expect(await MoveBuilder.read_module_info(hihi)).toEqual(
+      '{"address":[0,0,0,0,0,0,0,0,0,0,0,0,76,78,143,125,239,60,36,69,58,231,238,231,217,174,233,183,85,106,38,160],"name":"hihi"}'
     )
   })
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -15,7 +15,7 @@ describe('build move package', () => {
     bytecodeVersion: 7,
     compilerVersion: '2',
     languageVersion: '1',
-    addtionalNamedAddresses: [
+    additionalNamedAddresses: [
       ['test', '0x4'],
       ['test2', '0x4c4e8f7def3c24453ae7eee7d9aee9b7556a26a0'],
     ],


### PR DESCRIPTION
### Fix
* Resolve existing bug: [Issue #99](https://github.com/initia-labs/initia.js/issues/99).
* Fix compatibility issue caused by Buffer.to_string and Buffer.from_string handling of UTF-8.
### Test
* Add test cases to ensure full coverage of the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow with a new step for setting up Node.js, ensuring a consistent environment for builds and tests.
	- Added a new test case for decoding module bytes for a new entity, improving test coverage.

- **Bug Fixes**
	- Updated address in the test suite to ensure accurate testing of functionalities.

- **Tests**
	- Improved clarity in test variable names and expanded test cases for better validation of module information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->